### PR TITLE
Disabled client-side validation of item uniqueness.

### DIFF
--- a/src/Client/Pages/Characters/LootList/LootListEditorEntry.razor
+++ b/src/Client/Pages/Characters/LootList/LootListEditorEntry.razor
@@ -193,30 +193,30 @@ else if (!Entry.Won)
             }
 
             var dto = new LootListEntrySubmissionDto { EntryId = Entry.Id, ItemId = item?.Id, Justification = justification, RemoveIfInvalid = true };
-            if (item is not null)
-            {
-                var sameItemEntries = Editor.LootList.Entries.FindAll(e => e.Id != Entry.Id && e.ItemId == item.Id);
-                if (sameItemEntries.Count >= item.MaxCount)
-                {
-                    var firstMovableEntry = sameItemEntries.Where(e => !e.Won).OrderBy(e => e.Rank).FirstOrDefault();
+            //if (item is not null)
+            //{
+            //    var sameItemEntries = Editor.LootList.Entries.FindAll(e => e.Id != Entry.Id && e.ItemId == item.Id);
+            //    if (sameItemEntries.Count >= item.MaxCount)
+            //    {
+            //        var firstMovableEntry = sameItemEntries.Where(e => !e.Won).OrderBy(e => e.Rank).FirstOrDefault();
 
-                    if (firstMovableEntry is null)
-                    {
-                        // all added entries are already won.
-                        string msg = "You have already won this item";
+            //        if (firstMovableEntry is null)
+            //        {
+            //            // all added entries are already won.
+            //            string msg = "You have already won this item";
 
-                        if (item.MaxCount > 1)
-                        {
-                            msg = $"{msg} {item.MaxCount:N0} times";
-                        }
+            //            if (item.MaxCount > 1)
+            //            {
+            //                msg = $"{msg} {item.MaxCount:N0} times";
+            //            }
 
-                        Snackbar.Add(msg, Severity.Error);
-                        return;
-                    }
+            //            Snackbar.Add(msg, Severity.Error);
+            //            return;
+            //        }
 
-                    dto.SwapEntryId = firstMovableEntry.Id;
-                }
-            }
+            //        dto.SwapEntryId = firstMovableEntry.Id;
+            //    }
+            //}
 
             await Api.LootListEntries.Submit(Entry.Id, dto)
                 .OnSuccess(HandleSuccessNotDragged)

--- a/src/Server/Controllers/ItemsController.cs
+++ b/src/Server/Controllers/ItemsController.cs
@@ -56,7 +56,7 @@ public class ItemsController : ApiControllerV1
                 Name = item.Name,
                 Slot = item.Slot,
                 Type = item.Type,
-                MaxCount = (!item.IsUnique && (item.Slot == InventorySlot.Trinket || item.Slot == InventorySlot.Finger || item.Slot == InventorySlot.OneHand)) ? 2 : 1,
+                //MaxCount = (!item.IsUnique && (item.Slot == InventorySlot.Trinket || item.Slot == InventorySlot.Finger || item.Slot == InventorySlot.OneHand)) ? 2 : 1,
                 Heroic = item.Encounters.Any(e => e.Heroic)
             })
             .ToDictionaryAsync(item => item.Id);

--- a/src/Shared/DataTransfer/ItemDto.cs
+++ b/src/Shared/DataTransfer/ItemDto.cs
@@ -9,7 +9,7 @@ public class ItemDto
 
     public uint QuestId { get; set; }
 
-    public int MaxCount { get; set; }
+    //public int MaxCount { get; set; }
 
     public string? Name { get; set; }
 


### PR DESCRIPTION
Fixes issue with fury warriors unable to add two of one 2h weapon. Removes unintuitive behavior of forcing an item swap when picking an item already on the list.